### PR TITLE
[mx-29] Get rid of the ugly hack to overwrite the return type

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift4Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift4Codegen.java
@@ -825,19 +825,4 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
 
         return codegenModel;
     }
-
-    @Override
-    public CodegenOperation fromOperation(String path,
-                                          String httpMethod,
-                                          Operation operation,
-                                          Map<String, Model> definitions,
-                                          Swagger swagger) {
-                                              CodegenOperation op = super.fromOperation(path, httpMethod, operation, definitions, swagger);
-                                              for (CodegenResponse response: op.responses) {
-                                                  if (response.code == "204" || response.code == "302" || response.code == "303") {
-                                                    op.returnType = "Empty";
-                                                }
-                                              }
-                                              return op;
-                                          }
 }


### PR DESCRIPTION
Let's not hide the actual generator error under the rug, we can handle the `ERRORUNKNOWN` as a proper `Error` type in the templates. So, if anything goes wrong with the generator it should be free to emit this type as it indicates something is broken with our schema and not in the generator.