### PR TITLE
MX-29: [swift] Map type error to Empty type

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -3539,6 +3539,11 @@ public class DefaultCodegen {
         return new CliOption("library", sb.toString());
     }
 
+    protected String defaultSanitizedName() {
+        LOGGER.error("String to be sanitized is null. Default to ERROR_UNKNOWN");
+        return "ERROR_UNKNOWN";
+    }
+
     /**
      * Sanitize name (parameter, property, method, etc)
      *
@@ -3554,8 +3559,7 @@ public class DefaultCodegen {
 
         // better error handling when map/array type is invalid
         if (name == null) {
-            LOGGER.error("String to be sanitized is null. Default to ERROR_UNKNOWN");
-            return "ERROR_UNKNOWN";
+            return defaultSanitizedName();
         }
 
         // if the name is just '$', map it to 'value' for the time being.

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift4Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift4Codegen.java
@@ -518,6 +518,11 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
     }
 
     @Override
+    protected String defaultSanitizedName() {
+        return "Empty";
+    }
+
+    @Override
     public String toVarName(String name) {
         // sanitize name
         name = sanitizeName(name);


### PR DESCRIPTION
This seems like the cleanest fix for dealing with `ERROR_UNKNOWN`. 

Another fix I tried that also seems to be solving the problem is to handle `UntypedProperty` as something like a `void`. But since `void` is not in the original list of primitive types defined in `DefaultCodegen.typeMapping` and then further overridden in language specific subclasses. The fix with this problem is that it is touching too many parts and is not even guaranteed to work for every language case. 

This fix might serve us good for maintaining support of 3 languages and would have least conflicts with rebasing with the `upstream/master`